### PR TITLE
Change react-mirror dependency to use react-mirror2 as in styleguidist

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "peerDependencies": {
     "codemirror": ">=5.20.2",
     "react": ">=15",
-    "react-codemirror": ">=0.2.6",
+    "react-codemirror2": ">=0.0.13",
     "react-styleguidist": ">=5.4.4",
     "webpack": ">=1.14.0"
   },

--- a/src/components/Code.js
+++ b/src/components/Code.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Codemirror from 'react-codemirror'
+import CodeMirror from 'react-codemirror2'
 import 'codemirror/mode/diff/diff'
 import 'codemirror/mode/jsx/jsx'
 
@@ -14,7 +14,7 @@ const Code = (props, context) => {
     <div>
       <div className="snapguidist__label">{props.label}</div>
       <div className="snapguidist__code">
-        <Codemirror value={props.value} options={options} />
+        <CodeMirror value={props.value} options={options} />
       </div>
     </div>
   )

--- a/test/components/__snapshots__/Code.spec.js.snap
+++ b/test/components/__snapshots__/Code.spec.js.snap
@@ -1,41 +1,47 @@
-exports[`test works with diff 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`works with diff 1`] = `
 <div>
   <div
-    className="snapguidist__label">
+    className="snapguidist__label"
+  >
     label
   </div>
   <div
-    className="snapguidist__code">
-    <Component
+    className="snapguidist__code"
+  >
+    <CodeMirror
       options={
         Object {
           "mode": "diff",
           "theme": "theme",
         }
       }
-      preserveScrollPosition={false}
-      value="value" />
+      value="value"
+    />
   </div>
 </div>
 `;
 
-exports[`test works with jsx 1`] = `
+exports[`works with jsx 1`] = `
 <div>
   <div
-    className="snapguidist__label">
+    className="snapguidist__label"
+  >
     label
   </div>
   <div
-    className="snapguidist__code">
-    <Component
+    className="snapguidist__code"
+  >
+    <CodeMirror
       options={
         Object {
           "mode": "jsx",
           "theme": "theme",
         }
       }
-      preserveScrollPosition={false}
-      value="value" />
+      value="value"
+    />
   </div>
 </div>
 `;

--- a/test/components/__snapshots__/Test.spec.js.snap
+++ b/test/components/__snapshots__/Test.spec.js.snap
@@ -1,20 +1,26 @@
-exports[`test works on toggle 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`works on toggle 1`] = `
 <div
-  className="snapguidist__test snapguidist__test--fail snapguidist__test--expanded">
+  className="snapguidist__test snapguidist__test--fail snapguidist__test--expanded"
+>
   <div>
     <div>
       <button
         className="snapguidist__button"
         disabled={false}
-        onClick={[Function]}>
+        onClick={[Function]}
+      >
         Update
       </button>
       <button
         className="snapguidist__button"
         disabled={false}
-        onClick={[Function]}>
+        onClick={[Function]}
+      >
         <span
-          className="snapguidist__arrow snapguidist__arrow--expanded">
+          className="snapguidist__arrow snapguidist__arrow--expanded"
+        >
           ▼
         </span>
       </button>
@@ -23,33 +29,39 @@ exports[`test works on toggle 1`] = `
       <div>
         <Code
           label="Actual"
-          value="actual" />
+          value="actual"
+        />
         <Code
           label="Expected"
-          value="expected" />
+          value="expected"
+        />
       </div>
     </div>
   </div>
 </div>
 `;
 
-exports[`test works on update 1`] = `
+exports[`works on update 1`] = `
 <div
-  className="snapguidist__test snapguidist__test--fail">
+  className="snapguidist__test snapguidist__test--fail"
+>
   <div>
     <div>
       <button
         className="snapguidist__button"
         disabled={false}
-        onClick={[Function]}>
+        onClick={[Function]}
+      >
         Update
       </button>
       <button
         className="snapguidist__button"
         disabled={false}
-        onClick={[Function]}>
+        onClick={[Function]}
+      >
         <span
-          className="snapguidist__arrow">
+          className="snapguidist__arrow"
+        >
           ▼
         </span>
       </button>
@@ -58,33 +70,39 @@ exports[`test works on update 1`] = `
       <div>
         <Code
           label="Actual"
-          value="actual" />
+          value="actual"
+        />
         <Code
           label="Expected"
-          value="expected" />
+          value="expected"
+        />
       </div>
     </div>
   </div>
 </div>
 `;
 
-exports[`test works when fail, with diff 1`] = `
+exports[`works when fail, with diff 1`] = `
 <div
-  className="snapguidist__test snapguidist__test--fail">
+  className="snapguidist__test snapguidist__test--fail"
+>
   <div>
     <div>
       <button
         className="snapguidist__button"
         disabled={false}
-        onClick={[Function]}>
+        onClick={[Function]}
+      >
         Update
       </button>
       <button
         className="snapguidist__button"
         disabled={false}
-        onClick={[Function]}>
+        onClick={[Function]}
+      >
         <span
-          className="snapguidist__arrow">
+          className="snapguidist__arrow"
+        >
           ▼
         </span>
       </button>
@@ -93,33 +111,39 @@ exports[`test works when fail, with diff 1`] = `
       <div>
         <Code
           label="Actual"
-          value="actual" />
+          value="actual"
+        />
         <Code
           label="Expected"
-          value="expected" />
+          value="expected"
+        />
       </div>
     </div>
   </div>
 </div>
 `;
 
-exports[`test works when fail, without diff) 1`] = `
+exports[`works when fail, without diff) 1`] = `
 <div
-  className="snapguidist__test snapguidist__test--fail">
+  className="snapguidist__test snapguidist__test--fail"
+>
   <div>
     <div>
       <button
         className="snapguidist__button"
         disabled={false}
-        onClick={[Function]}>
+        onClick={[Function]}
+      >
         Update
       </button>
       <button
         className="snapguidist__button"
         disabled={false}
-        onClick={[Function]}>
+        onClick={[Function]}
+      >
         <span
-          className="snapguidist__arrow">
+          className="snapguidist__arrow"
+        >
           ▼
         </span>
       </button>
@@ -128,29 +152,34 @@ exports[`test works when fail, without diff) 1`] = `
       <Code
         diff={true}
         label="Difference"
-        value="diff" />
+        value="diff"
+      />
     </div>
   </div>
 </div>
 `;
 
-exports[`test works when is fetching 1`] = `
+exports[`works when is fetching 1`] = `
 <div
-  className="snapguidist__test snapguidist__test--fail">
+  className="snapguidist__test snapguidist__test--fail"
+>
   <div>
     <div>
       <button
         className="snapguidist__button"
         disabled={true}
-        onClick={[Function]}>
+        onClick={[Function]}
+      >
         Update
       </button>
       <button
         className="snapguidist__button"
         disabled={true}
-        onClick={[Function]}>
+        onClick={[Function]}
+      >
         <span
-          className="snapguidist__arrow">
+          className="snapguidist__arrow"
+        >
           ▼
         </span>
       </button>
@@ -159,17 +188,20 @@ exports[`test works when is fetching 1`] = `
       <div>
         <Code
           label="Actual"
-          value="actual" />
+          value="actual"
+        />
         <Code
           label="Expected"
-          value="expected" />
+          value="expected"
+        />
       </div>
     </div>
   </div>
 </div>
 `;
 
-exports[`test works when pass 1`] = `
+exports[`works when pass 1`] = `
 <div
-  className="snapguidist__test snapguidist__test--pass" />
+  className="snapguidist__test snapguidist__test--pass"
+/>
 `;

--- a/test/core/__snapshots__/snapshot.spec.js.snap
+++ b/test/core/__snapshots__/snapshot.spec.js.snap
@@ -1,4 +1,6 @@
-exports[`test fails if the type changes 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fails if the type changes 1`] = `
 Object {
   "actual": "<span>
   <span />


### PR DESCRIPTION
This should fix #20.
I left it as peerDependency for now and I required a minimum version `0.0.13` as it's the version used in `styleguidist`

Changes are tested installing the library from github and it seems working as expected.
Let me know if you need anything else

Edit: I just realized I installed a different version of jest-cli and it cause to update all the snapshot tests, is it allright or it's better to restore them as they were before?