### PR TITLE
Move codemirror and react-codemirror in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,17 +52,17 @@
   "dependencies": {
     "body-parser": "1.15.2",
     "classnames": "2.2.5",
+    "codemirror": "5.20.2",
     "cors": "2.8.1",
     "jest-diff": "18.1.0",
     "jest-snapshot": "18.1.0",
+    "react-codemirror": "0.2.6",
     "react-test-renderer": "15.6.1",
     "strip-ansi": "3.0.1",
     "unfetch": "2.1.2"
   },
   "peerDependencies": {
-    "codemirror": ">=5.20.2",
     "react": ">=15",
-    "react-codemirror": ">=0.2.6",
     "react-styleguidist": ">=5.4.4",
     "webpack": ">=1.14.0"
   },

--- a/test/components/__snapshots__/Code.spec.js.snap
+++ b/test/components/__snapshots__/Code.spec.js.snap
@@ -6,14 +6,13 @@ exports[`test works with diff 1`] = `
   </div>
   <div
     className="snapguidist__code">
-    <Component
+    <CodeMirror
       options={
         Object {
           "mode": "diff",
           "theme": "theme",
         }
       }
-      preserveScrollPosition={false}
       value="value" />
   </div>
 </div>
@@ -27,14 +26,13 @@ exports[`test works with jsx 1`] = `
   </div>
   <div
     className="snapguidist__code">
-    <Component
+    <CodeMirror
       options={
         Object {
           "mode": "jsx",
           "theme": "theme",
         }
       }
-      preserveScrollPosition={false}
       value="value" />
   </div>
 </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1089,7 +1089,7 @@ clap@^1.0.9:
   dependencies:
     chalk "^1.1.3"
 
-classnames@2.2.5, classnames@^2.2.5:
+classnames@2.2.5, classnames@^2.2.3, classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
@@ -1173,7 +1173,11 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-codemirror@^5.18.2, codemirror@^5.26.0:
+codemirror@5.20.2:
+  version "5.20.2"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.20.2.tgz#918e0ece96d57a99030b2f8b33011284bed5217a"
+
+codemirror@^5.13.4, codemirror@^5.18.2, codemirror@^5.26.0:
   version "5.26.0"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.26.0.tgz#bcbee86816ed123870c260461c2b5c40b68746e5"
 
@@ -3578,7 +3582,7 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
-lodash.debounce@^4.0.8:
+lodash.debounce@^4.0.4, lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
 
@@ -4752,6 +4756,14 @@ rc@~1.1.6:
 react-addons-test-utils@15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.6.0.tgz#062d36117fe8d18f3ba5e06eb33383b0b85ea5b9"
+
+react-codemirror@0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/react-codemirror/-/react-codemirror-0.2.6.tgz#e71e35717ce6effae68df1dbf2b5a75b84a44f84"
+  dependencies:
+    classnames "^2.2.3"
+    codemirror "^5.13.4"
+    lodash.debounce "^4.0.4"
 
 react-codemirror@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR will replace #21 

I moved the dependencies from peer to be normal dependencies as discussed with @sapegin.

I didn't upgrade react-mirror to the version 2 but we can easily do it in a separate PR if you think it should be done.

I haven't test the installation but it should work as expected since nothing has changed.