### PR TITLE
Updated react-codemirror to react-codemirror2

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "cors": "2.8.1",
     "jest-diff": "18.1.0",
     "jest-snapshot": "18.1.0",
-    "react-codemirror2": "2.0.0",
+    "react-codemirror2": "2.0.1",
     "react-test-renderer": "15.6.1",
     "strip-ansi": "3.0.1",
     "unfetch": "2.1.2"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "cors": "2.8.1",
     "jest-diff": "18.1.0",
     "jest-snapshot": "18.1.0",
-    "react-codemirror": "0.2.6",
+    "react-codemirror2": "2.0.0",
     "react-test-renderer": "15.6.1",
     "strip-ansi": "3.0.1",
     "unfetch": "2.1.2"

--- a/test/components/__snapshots__/Code.spec.js.snap
+++ b/test/components/__snapshots__/Code.spec.js.snap
@@ -6,13 +6,14 @@ exports[`test works with diff 1`] = `
   </div>
   <div
     className="snapguidist__code">
-    <CodeMirror
+    <Component
       options={
         Object {
           "mode": "diff",
           "theme": "theme",
         }
       }
+      preserveScrollPosition={false}
       value="value" />
   </div>
 </div>
@@ -26,13 +27,14 @@ exports[`test works with jsx 1`] = `
   </div>
   <div
     className="snapguidist__code">
-    <CodeMirror
+    <Component
       options={
         Object {
           "mode": "jsx",
           "theme": "theme",
         }
       }
+      preserveScrollPosition={false}
       value="value" />
   </div>
 </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1089,7 +1089,7 @@ clap@^1.0.9:
   dependencies:
     chalk "^1.1.3"
 
-classnames@2.2.5, classnames@^2.2.3, classnames@^2.2.5:
+classnames@2.2.5, classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
@@ -1177,7 +1177,7 @@ codemirror@5.20.2:
   version "5.20.2"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.20.2.tgz#918e0ece96d57a99030b2f8b33011284bed5217a"
 
-codemirror@^5.13.4, codemirror@^5.18.2, codemirror@^5.26.0:
+codemirror@^5.18.2, codemirror@^5.26.0:
   version "5.26.0"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.26.0.tgz#bcbee86816ed123870c260461c2b5c40b68746e5"
 
@@ -3582,7 +3582,7 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
-lodash.debounce@^4.0.4, lodash.debounce@^4.0.8:
+lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
 
@@ -4757,13 +4757,9 @@ react-addons-test-utils@15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.6.0.tgz#062d36117fe8d18f3ba5e06eb33383b0b85ea5b9"
 
-react-codemirror@0.2.6:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/react-codemirror/-/react-codemirror-0.2.6.tgz#e71e35717ce6effae68df1dbf2b5a75b84a44f84"
-  dependencies:
-    classnames "^2.2.3"
-    codemirror "^5.13.4"
-    lodash.debounce "^4.0.4"
+react-codemirror2@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-codemirror2/-/react-codemirror2-2.0.1.tgz#112f2f17b32c528d11482a03c4feb86d5259b3af"
 
 react-codemirror@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
On @sapegin's advice this dependency should be updated to fix a bug with snapshot CSS highlighting.

**Context**:

* https://github.com/styleguidist/snapguidist/issues/23
* https://github.com/styleguidist/react-styleguidist/issues/611