### PR TITLE
Prevent crashing when a component is null

### DIFF
--- a/src/core/snapshot.js
+++ b/src/core/snapshot.js
@@ -10,14 +10,16 @@ const typeOf = { value: Symbol.for('react.test.json') }
 const cleanUp = (result) => {
   result.actual = result.actual.trim()
   result.expected = result.expected.trim()
-  result.diff = result.diff.replace(/\n[ ]+\n/g, '\n\n')
+  result.diff = (result.diff || '').replace(/\n[ ]+\n/g, '\n\n')
 }
 
 const snapshot = (name, tree, update) => {
   const destination = path.resolve(base, `${name}.snap`)
   const state = new SnapshotState(null, update, destination)
 
-  Object.defineProperty(tree, '$$typeof', typeOf)
+  if (tree) {
+    Object.defineProperty(tree, '$$typeof', typeOf)
+  }
 
   const result = state.match(name, tree)
   state.save(update)

--- a/test/core/__snapshots__/snapshot.spec.js.snap
+++ b/test/core/__snapshots__/snapshot.spec.js.snap
@@ -1,3 +1,23 @@
+exports[`test fails if new is null but old is not 1`] = `
+Object {
+  "actual": "null",
+  "count": 1,
+  "diff": "",
+  "expected": "<div />",
+  "pass": false,
+}
+`;
+
+exports[`test fails if old was null but new is not 1`] = `
+Object {
+  "actual": "<div />",
+  "count": 1,
+  "diff": "",
+  "expected": "null",
+  "pass": false,
+}
+`;
+
 exports[`test fails if the type changes 1`] = `
 Object {
   "actual": "<span>
@@ -17,5 +37,11 @@ Object {
   <span />
 </div>",
   "pass": false,
+}
+`;
+
+exports[`test passes if new and old are null 1`] = `
+Object {
+  "pass": true,
 }
 `;

--- a/test/core/snapshot.spec.js
+++ b/test/core/snapshot.spec.js
@@ -45,8 +45,9 @@ test('passes if null, first time', () => {
 })
 
 test('passes if new and old are null', () => {
-  snapshot('name', null)
-  const result = snapshot('name1', null)
+  const name = 'both-null'
+  snapshot(name, null)
+  const result = snapshot(name, null)
 
   expect(result).toMatchSnapshot()
 })

--- a/test/core/snapshot.spec.js
+++ b/test/core/snapshot.spec.js
@@ -36,3 +36,48 @@ test('does not fail if update is true', () => {
 
   expect(result).toEqual({ pass: true })
 })
+
+test('passes if null, first time', () => {
+  const tree = null
+  const result = snapshot('name', tree)
+
+  expect(result).toEqual({ pass: true })
+})
+
+test('passes if new and old are null', () => {
+  snapshot('name', null)
+  const result = snapshot('name1', null)
+
+  expect(result).toMatchSnapshot()
+})
+
+test('fails if old was null but new is not', () => {
+  const name = 'old-was-null'
+  snapshot(name, null)
+
+  const tree = { type: 'div' }
+  const result = snapshot(name, tree)
+
+  expect(result).toMatchSnapshot()
+})
+
+test('fails if new is null but old is not', () => {
+  const name = 'new-is-null'
+  const tree = { type: 'div' }
+  snapshot(name, tree)
+
+  const result = snapshot(name, null)
+
+  expect(result).toMatchSnapshot()
+})
+
+test('null tree does not fail if update is true', () => {
+  const name = 'null-with-update'
+  const tree = { type: 'div' }
+  snapshot(name, tree)
+
+  const update = true
+  const result = snapshot(name, null, update)
+
+  expect(result).toEqual({ pass: true })
+})


### PR DESCRIPTION
I'm seeing this error in the console when a component returns `null` from its render function: `TypeError: Object.defineProperty called on non-object`

I've added some failing specs and modified `core/snapshot.js` to make them pass.

PS. thanks for this library!